### PR TITLE
Clarify set level API end_date default behavior

### DIFF
--- a/source/customer_api.rst
+++ b/source/customer_api.rst
@@ -1216,6 +1216,7 @@ user          Yes         A string indicating customer's email, Member ID, mobil
 level         Yes         A level numerical value
 upgrade_only  No          A boolean value, default to false. If set to true, ``level`` must be higher than user's current level
 end_date      No          If set, ``level`` will only be set until the specified date. Must not be earlier than today.
+                          If not set, will be set for 365 days (this period is customizable)
 ============= =========== =========================
 
 Example of API call request using cURL:


### PR DESCRIPTION
Ref stamps-id/stamps#19177

![image](https://github.com/ui/stamps-api-docs/assets/30365484/ed972ec9-c110-41b4-b2ea-97c6fdb5b5ef)