### PR TITLE
Specify sphinx configuration file in readthedocs yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,6 +4,9 @@
 # Required
 version: 2
 
+sphinx:
+  configuration: source/conf.py
+
 # Set the OS, Python version and other tools you might need
 build:
   os: ubuntu-22.04


### PR DESCRIPTION
deployment failed, need to explicitly specify the config file
https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/